### PR TITLE
Update protocol version.

### DIFF
--- a/serialize.h
+++ b/serialize.h
@@ -60,7 +60,7 @@ class CDataStream;
 class CAutoFile;
 static const unsigned int MAX_SIZE = 0x02000000;
 
-static const int PROTOCOL_VERSION = 60006;
+static const int PROTOCOL_VERSION = 70002;
 
 // Used to bypass the rule against non-const reference to temporary
 // where it makes sense with wrappers such as CFlatData or CTxDB


### PR DESCRIPTION
The v0.7.3 release will start banning this seeder because its protocol is too old... so bump it up to a modern one :rocket: 